### PR TITLE
Fix log for number of cores used

### DIFF
--- a/R/gt3x_2_csv.R
+++ b/R/gt3x_2_csv.R
@@ -384,7 +384,7 @@ gt3x_2_csv <- function(gt3x_files = NULL, outdir = NULL, progress = FALSE,
       registerDoSNOW(cluster)
       
       if(verbose){
-        log_success("Cluster allocated for parallelization. Using ", detectCores(), " cores.")
+        log_success("Cluster allocated for parallelization. Using ", cores, " cores.")
       }
     } else {
       registerDoSEQ()


### PR DESCRIPTION
I was getting confused by this line in the log when manually specifying the number of cores. I've just changed to reflect the actual number of cores being used.