### PR TITLE
Fix C stack error

### DIFF
--- a/R/gt3x_2_csv.R
+++ b/R/gt3x_2_csv.R
@@ -165,9 +165,9 @@ save_accel <- function(acc.file, outdir = NULL, verbose = FALSE){
                         imputeZeroes = TRUE) %>%
                 # Here, we drop the 'timestamp' column:
                 as.data.table(.[, -4]) %>%
-                transmute(`Accelerometer X` = Y %>% as.character,
-                          `Accelerometer Y` = X %>% as.character,
-                          `Accelerometer Z` = Z %>% as.character)
+                transmute(`Accelerometer X` = Y %>% as.double,
+                          `Accelerometer Y` = X %>% as.double,
+                          `Accelerometer Z` = Z %>% as.double)
 
   # Writing acceleration data in csv:
   if(verbose){


### PR DESCRIPTION
Using strings for the `accel_df` creates null characters that cannot be parsed by `vroom_write`. Switching to `as.double` keeps the output exactly the same but prevents the nulls from being made.